### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/325/71/85632571.geojson
+++ b/data/856/325/71/85632571.geojson
@@ -957,6 +957,10 @@
     },
     "wof:country":"BZ",
     "wof:country_alpha3":"BLZ",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"9fa838eb4c2323a96473df803cf12805",
     "wof:hierarchy":[
         {
@@ -971,7 +975,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566633196,
+    "wof:lastmodified":1582343856,
     "wof:name":"Belize",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/693/21/85669321.geojson
+++ b/data/856/693/21/85669321.geojson
@@ -246,6 +246,9 @@
         "wk:page":"Belize District"
     },
     "wof:country":"BZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e4863fea5378872ac12cc35ac34512e",
     "wof:hierarchy":[
         {
@@ -261,7 +264,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566633195,
+    "wof:lastmodified":1582343855,
     "wof:name":"Belize",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/37/85669337.geojson
+++ b/data/856/693/37/85669337.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Stann Creek District"
     },
     "wof:country":"BZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d41acdb8e637ffbeecfe767243797a9b",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566633196,
+    "wof:lastmodified":1582343855,
     "wof:name":"Stann Creek",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/43/85669343.geojson
+++ b/data/856/693/43/85669343.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Toledo District"
     },
     "wof:country":"BZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e8d9841c93d228de6f354c219856e44",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566633195,
+    "wof:lastmodified":1582343855,
     "wof:name":"Toledo",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/857/935/27/85793527.geojson
+++ b/data/857/935/27/85793527.geojson
@@ -114,6 +114,9 @@
         "qs_pg:id":1082568
     },
     "wof:country":"BZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e27f51ea1c223d0732948d2a59ade325",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566633194,
+    "wof:lastmodified":1582343855,
     "wof:name":"Fort George",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/442/105/890442105.geojson
+++ b/data/890/442/105/890442105.geojson
@@ -519,6 +519,9 @@
     },
     "wof:country":"BZ",
     "wof:created":1469052350,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"53dcd9dd9d659f53b999fd1fdb7109cd",
     "wof:hierarchy":[
         {
@@ -529,7 +532,7 @@
         }
     ],
     "wof:id":890442105,
-    "wof:lastmodified":1566633228,
+    "wof:lastmodified":1582343856,
     "wof:name":"Belmopan",
     "wof:parent_id":85669323,
     "wof:placetype":"locality",

--- a/data/890/451/721/890451721.geojson
+++ b/data/890/451/721/890451721.geojson
@@ -228,6 +228,9 @@
     },
     "wof:country":"BZ",
     "wof:created":1469052791,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f04176c74733ae9409e0e85f711e32a3",
     "wof:hierarchy":[
         {
@@ -238,7 +241,7 @@
         }
     ],
     "wof:id":890451721,
-    "wof:lastmodified":1566633228,
+    "wof:lastmodified":1582343857,
     "wof:name":"Dangriga",
     "wof:parent_id":85669337,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.