### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/583/071/5/1125830715.geojson
+++ b/data/112/583/071/5/1125830715.geojson
@@ -34,6 +34,9 @@
     "name:fra_x_preferred":[
         "Hattieville"
     ],
+    "name:jpn_x_preferred":[
+        "\u30cf\u30c6\u30a3\u30f4\u30a3\u30eb"
+    ],
     "name:lit_x_preferred":[
         "Hatjevilis"
     ],
@@ -41,6 +44,9 @@
         "Hattieville"
     ],
     "name:nld_x_preferred":[
+        "Hattieville"
+    ],
+    "name:nob_x_preferred":[
         "Hattieville"
     ],
     "name:pol_x_preferred":[
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":1125830715,
-    "wof:lastmodified":1566633229,
+    "wof:lastmodified":1690863844,
     "wof:name":"Hattieville",
     "wof:parent_id":85669321,
     "wof:placetype":"locality",

--- a/data/114/190/812/1/1141908121.geojson
+++ b/data/114/190/812/1/1141908121.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-88.1883744728,17.4987109568,-88.1883744728,17.4987109568",
+    "geom:bbox":"-88.188374,17.498711,-88.188374,17.498711",
     "geom:latitude":17.498711,
     "geom:longitude":-88.188374,
     "gn:country":"BZ",
@@ -21,8 +21,14 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":8.0,
+    "name:afr_x_preferred":[
+        "Belize-stad"
+    ],
     "name:ara_x_preferred":[
         "\u0645\u062f\u064a\u0646\u0629 \u0628\u0644\u064a\u0632"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0644\u064a\u0632"
     ],
     "name:ast_x_preferred":[
         "Ciud\u00e1 de Belice"
@@ -64,7 +70,8 @@
         "\u03a0\u03cc\u03bb\u03b7 \u03c4\u03bf\u03c5 \u039c\u03c0\u03b5\u03bb\u03af\u03b6"
     ],
     "name:ell_x_variant":[
-        "\u03a0\u03cc\u03bb\u03b7 \u03c4\u03bf\u03c5 \u039c\u03c0\u03b5\u03bb\u03af\u03b6\u03b5"
+        "\u03a0\u03cc\u03bb\u03b7 \u03c4\u03bf\u03c5 \u039c\u03c0\u03b5\u03bb\u03af\u03b6\u03b5",
+        "\u039c\u03c0\u03b5\u03bb\u03af\u03b6 \u03a3\u03af\u03c4\u03b9"
     ],
     "name:eng_x_preferred":[
         "Belize City"
@@ -85,6 +92,9 @@
         "Belize City"
     ],
     "name:fra_x_preferred":[
+        "Belize City"
+    ],
+    "name:frr_x_preferred":[
         "Belize City"
     ],
     "name:glg_x_preferred":[
@@ -108,17 +118,29 @@
     "name:hun_x_preferred":[
         "Belizev\u00e1ros"
     ],
+    "name:hye_x_preferred":[
+        "\u0532\u0565\u056c\u056b\u0566"
+    ],
+    "name:ido_x_preferred":[
+        "Belize City"
+    ],
     "name:ile_x_preferred":[
         "Belize City"
     ],
     "name:ind_x_preferred":[
         "Belize City"
     ],
+    "name:ind_x_variant":[
+        "Kota Belize"
+    ],
     "name:isl_x_preferred":[
         "Bel\u00eds"
     ],
     "name:ita_x_preferred":[
         "Belize City"
+    ],
+    "name:ita_x_variant":[
+        "Belize"
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30ea\u30fc\u30ba\u30b7\u30c6\u30a3"
@@ -153,6 +175,9 @@
     "name:mkd_x_preferred":[
         "\u0411\u0435\u043b\u0438\u0437\u0435"
     ],
+    "name:mkd_x_variant":[
+        "\u0411\u0435\u043b\u0438\u0437"
+    ],
     "name:mon_x_preferred":[
         "\u0411\u0435\u043b\u0438\u0437"
     ],
@@ -182,6 +207,9 @@
     ],
     "name:oci_x_preferred":[
         "Belize City"
+    ],
+    "name:oss_x_preferred":[
+        "\u0411\u0435\u043b\u0438\u0437"
     ],
     "name:pap_x_preferred":[
         "Belize City"
@@ -231,6 +259,9 @@
     "name:swe_x_preferred":[
         "Belize City"
     ],
+    "name:szl_x_preferred":[
+        "Belize City"
+    ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0bb2\u0bc0\u0b9a\u0bc1"
     ],
@@ -272,6 +303,9 @@
     ],
     "name:war_x_preferred":[
         "Syudad han Belize"
+    ],
+    "name:wuu_x_preferred":[
+        "\u4f2f\u5229\u5179\u57ce"
     ],
     "name:zho_x_preferred":[
         "\u4f2f\u5229\u5179\u5e02"
@@ -397,7 +431,7 @@
     },
     "wof:country":"BZ",
     "wof:created":1499130823,
-    "wof:geomhash":"b2c3558468f284c6a96237bfbaafac39",
+    "wof:geomhash":"16216a4529522e11eb6a02d70378633d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -407,7 +441,7 @@
         }
     ],
     "wof:id":1141908121,
-    "wof:lastmodified":1566633245,
+    "wof:lastmodified":1690863844,
     "wof:name":"Belize City",
     "wof:parent_id":85669321,
     "wof:placetype":"locality",
@@ -421,10 +455,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -88.18837447279611,
-    17.49871095679219,
-    -88.18837447279611,
-    17.49871095679219
+    -88.188374,
+    17.498711,
+    -88.188374,
+    17.498711
 ],
-  "geometry": {"coordinates":[-88.18837447279611,17.49871095679219],"type":"Point"}
+  "geometry": {"coordinates":[-88.188374,17.498711],"type":"Point"}
 }

--- a/data/421/173/003/421173003.geojson
+++ b/data/421/173/003/421173003.geojson
@@ -17,6 +17,15 @@
     "mz:is_current":1,
     "mz:min_zoom":6.7,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Orange Walk Town"
+    ],
+    "name:aze_x_preferred":[
+        "Orandj Uolk"
+    ],
+    "name:bel_x_preferred":[
+        "\u041e\u0440\u044b\u043d\u0434\u0436-\u0423\u043e\u043b\u043a"
+    ],
     "name:bel_x_variant":[
         "\u041e\u0440\u0430\u043d\u0436-\u040e\u043e\u043a"
     ],
@@ -36,6 +45,9 @@
         "Orange Walk"
     ],
     "name:eng_x_variant":[
+        "Orange Walk Town"
+    ],
+    "name:epo_x_preferred":[
         "Orange Walk Town"
     ],
     "name:fra_x_preferred":[
@@ -74,6 +86,9 @@
     "name:mar_x_preferred":[
         "\u0911\u0930\u0947\u0902\u091c \u0935\u0949\u0915 \u091f\u093e\u0909\u0928"
     ],
+    "name:nds_x_preferred":[
+        "Orange Walk"
+    ],
     "name:nld_x_preferred":[
         "Orange Walk Town"
     ],
@@ -103,6 +118,9 @@
     ],
     "name:tur_x_preferred":[
         "Orange Walk"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041e\u0440\u0438\u043d\u0434\u0436-\u0412\u043e\u043b\u043a"
     ],
     "name:urd_x_preferred":[
         "\u0627\u0648\u0631\u0646\u062c \u0648\u0627\u06a9 \u0679\u0627\u0624\u0646"
@@ -253,7 +271,7 @@
         }
     ],
     "wof:id":421173003,
-    "wof:lastmodified":1636500459,
+    "wof:lastmodified":1690863841,
     "wof:name":"Orange Walk",
     "wof:parent_id":85669331,
     "wof:placetype":"locality",

--- a/data/421/173/023/421173023.geojson
+++ b/data/421/173/023/421173023.geojson
@@ -17,8 +17,17 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "San Ignacio"
+    ],
+    "name:bel_x_preferred":[
+        "\u0421\u0430\u043d-\u0406\u0433\u043d\u0430\u0441\u0456\u0430"
+    ],
     "name:bel_x_variant":[
         "\u0421\u0430\u043d-\u0406\u0433\u043d\u0430\u0441\u0456\u0451"
+    ],
+    "name:cat_x_preferred":[
+        "San Ignacio"
     ],
     "name:ceb_x_preferred":[
         "San Ignacio"
@@ -29,7 +38,13 @@
     "name:eng_x_preferred":[
         "San Ignacio"
     ],
+    "name:epo_x_preferred":[
+        "San Ignacio"
+    ],
     "name:fra_x_preferred":[
+        "San Ignacio"
+    ],
+    "name:frr_x_preferred":[
         "San Ignacio"
     ],
     "name:heb_x_preferred":[
@@ -58,6 +73,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0938\u093e\u0928 \u0907\u0917\u094d\u0928\u093e\u0938\u093f\u092f\u094b"
+    ],
+    "name:nds_x_preferred":[
+        "San Ignacio/Santa Elena"
     ],
     "name:nld_x_preferred":[
         "San Ignacio"
@@ -94,6 +112,9 @@
     ],
     "name:swe_x_preferred":[
         "San Ignacio"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0430\u043d-\u0418\u0433\u043d\u0430\u0441\u0438\u043e"
     ],
     "name:tur_x_preferred":[
         "San Ignacio"
@@ -162,7 +183,7 @@
         }
     ],
     "wof:id":421173023,
-    "wof:lastmodified":1636500459,
+    "wof:lastmodified":1690863841,
     "wof:name":"San Ignacio",
     "wof:parent_id":85669323,
     "wof:placetype":"locality",

--- a/data/421/173/635/421173635.geojson
+++ b/data/421/173/635/421173635.geojson
@@ -26,6 +26,9 @@
     "name:nld_x_preferred":[
         "Bermudian Landing"
     ],
+    "name:por_x_preferred":[
+        "Bermudian Landing"
+    ],
     "qs:gn_country":"BZ",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":3582661,
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":421173635,
-    "wof:lastmodified":1566633226,
+    "wof:lastmodified":1690863841,
     "wof:name":"Bermudian Landing",
     "wof:parent_id":85669321,
     "wof:placetype":"locality",

--- a/data/421/177/307/421177307.geojson
+++ b/data/421/177/307/421177307.geojson
@@ -20,6 +20,9 @@
     "name:afr_x_preferred":[
         "San Antonio"
     ],
+    "name:aka_x_preferred":[
+        "San Antonio"
+    ],
     "name:amh_x_preferred":[
         "\u1233\u1295 \u12a0\u1295\u1276\u1292\u12ee"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:arg_x_preferred":[
         "San Antonio"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u0627\u0646\u0637\u0648\u0646\u064a\u0648"
     ],
     "name:ast_x_preferred":[
         "San Antonio"
@@ -68,10 +74,16 @@
     "name:che_x_preferred":[
         "\u0421\u0430\u043d-\u0410\u043d\u0442\u043e\u043d\u0438\u043e"
     ],
+    "name:ckb_x_preferred":[
+        "\u0633\u0627\u0646 \u0626\u06d5\u0646\u062a\u06c6\u0646\u06cc\u06c6"
+    ],
     "name:cor_x_preferred":[
         "San Antonio"
     ],
     "name:cym_x_preferred":[
+        "San Antonio"
+    ],
+    "name:dag_x_preferred":[
         "San Antonio"
     ],
     "name:dan_x_preferred":[
@@ -128,6 +140,9 @@
     "name:glg_x_preferred":[
         "San Antonio"
     ],
+    "name:grn_x_preferred":[
+        "San Antonio"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8 \u0a8f\u0aa8\u0acd\u0a9f\u0acb\u0aa8\u0abf\u0aaf\u0acb"
     ],
@@ -152,6 +167,12 @@
     "name:hye_x_preferred":[
         "\u054d\u0561\u0576 \u0531\u0576\u057f\u0578\u0576\u056b\u0578"
     ],
+    "name:ido_x_preferred":[
+        "San Antonio"
+    ],
+    "name:ile_x_preferred":[
+        "San Antonio"
+    ],
     "name:ilo_x_preferred":[
         "San Antonio"
     ],
@@ -173,6 +194,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30a2\u30f3\u30c8\u30cb\u30aa"
     ],
+    "name:jpn_x_variant":[
+        "\u30b5\u30f3\u30fb\u30a2\u30f3\u30c8\u30cb\u30aa"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0ccd\u0caf\u0cbe\u0ca8\u0ccd \u0c86\u0c82\u0c9f\u0ccb\u0ca8\u0cbf\u0caf\u0ccb"
     ],
@@ -188,11 +212,17 @@
     "name:kor_x_preferred":[
         "\uc0cc\uc548\ud1a0\ub2c8\uc624"
     ],
+    "name:kur_x_preferred":[
+        "San Antonio"
+    ],
     "name:lad_x_preferred":[
         "San Antonio"
     ],
     "name:lat_x_preferred":[
         "Sanctus Antonius"
+    ],
+    "name:lat_x_variant":[
+        "Antoniopolis"
     ],
     "name:lav_x_preferred":[
         "Sanantonio"
@@ -205,6 +235,9 @@
     ],
     "name:lit_x_preferred":[
         "San Antonijas"
+    ],
+    "name:lld_x_preferred":[
+        "San Antonio"
     ],
     "name:ltz_x_preferred":[
         "San Antonio"
@@ -230,11 +263,17 @@
     "name:msa_x_preferred":[
         "San Antonio"
     ],
+    "name:mya_x_preferred":[
+        "\u1006\u1014\u103a \u1021\u1014\u103a\u1010\u102d\u102f\u1014\u102e\u101a\u102d\u102f"
+    ],
     "name:nah_x_preferred":[
         "San Antonio"
     ],
     "name:nan_x_preferred":[
         "San Antonio"
+    ],
+    "name:nav_x_preferred":[
+        "Kin Hal\u00e1n\u00edtah"
     ],
     "name:nep_x_preferred":[
         "\u0938\u093e\u0928 \u0906\u0928\u094d\u091f\u094b\u0928\u093f\u092f\u094b"
@@ -294,6 +333,9 @@
         "San Antonio"
     ],
     "name:slv_x_preferred":[
+        "San Antonio"
+    ],
+    "name:smn_x_preferred":[
         "San Antonio"
     ],
     "name:som_x_preferred":[
@@ -374,6 +416,9 @@
     "name:war_x_preferred":[
         "San Antonio"
     ],
+    "name:wuu_x_preferred":[
+        "\u5723\u5b89\u4e1c\u5c3c\u5965"
+    ],
     "name:xmf_x_preferred":[
         "\u10e1\u10d0\u10dc-\u10d0\u10dc\u10d7\u10dd\u10dc\u10d8\u10dd"
     ],
@@ -432,7 +477,7 @@
         }
     ],
     "wof:id":421177307,
-    "wof:lastmodified":1566633227,
+    "wof:lastmodified":1690863842,
     "wof:name":"San Antonio",
     "wof:parent_id":85669343,
     "wof:placetype":"locality",

--- a/data/421/177/431/421177431.geojson
+++ b/data/421/177/431/421177431.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:cym_x_preferred":[
+        "Y Cwymp Mawr"
+    ],
     "name:eng_x_preferred":[
         "The Big Fall"
     ],
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421177431,
-    "wof:lastmodified":1566633227,
+    "wof:lastmodified":1690863843,
     "wof:name":"Big Fall",
     "wof:parent_id":85669343,
     "wof:placetype":"locality",

--- a/data/421/196/263/421196263.geojson
+++ b/data/421/196/263/421196263.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0645\u062f\u0641\u0646"
     ],
+    "name:cat_x_preferred":[
+        "pati d'esgl\u00e9sia"
+    ],
+    "name:cym_x_preferred":[
+        "mynwent eglwys"
+    ],
     "name:dan_x_preferred":[
         "kirkeg\u00e5rd"
     ],
@@ -53,6 +59,9 @@
     "name:glg_x_preferred":[
         "Adro"
     ],
+    "name:jav_x_preferred":[
+        "Kerkop"
+    ],
     "name:jpn_x_preferred":[
         "\u6559\u4f1a\u4ed8\u5c5e\u5893\u5730"
     ],
@@ -71,14 +80,38 @@
     "name:nob_x_preferred":[
         "kirkeg\u00e5rd"
     ],
+    "name:pol_x_preferred":[
+        "teren przyko\u015bcielny"
+    ],
     "name:por_x_preferred":[
         "Adro"
     ],
     "name:por_x_variant":[
         "adro"
     ],
+    "name:rus_x_preferred":[
+        "\u0446\u0435\u0440\u043a\u043e\u0432\u043d\u043e\u0435 \u043a\u043b\u0430\u0434\u0431\u0438\u0449\u0435"
+    ],
+    "name:sma_x_preferred":[
+        "g\u00e6rhkoegaertene"
+    ],
+    "name:sme_x_preferred":[
+        "girkoeanan"
+    ],
+    "name:smj_x_preferred":[
+        "girkkog\u00e1rdde"
+    ],
+    "name:smn_x_preferred":[
+        "kirkkoeenn\u00e2m"
+    ],
+    "name:sms_x_preferred":[
+        "ceerkavm\u00e4dd"
+    ],
     "name:spa_x_preferred":[
         "Adro"
+    ],
+    "name:swe_x_preferred":[
+        "kyrkog\u00e5rd"
     ],
     "name:zho_x_preferred":[
         "\u6559\u5802\u5893\u5730"
@@ -127,7 +160,7 @@
         }
     ],
     "wof:id":421196263,
-    "wof:lastmodified":1566633227,
+    "wof:lastmodified":1690863842,
     "wof:name":"Churchyard",
     "wof:parent_id":85669321,
     "wof:placetype":"locality",

--- a/data/421/201/237/421201237.geojson
+++ b/data/421/201/237/421201237.geojson
@@ -20,7 +20,13 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0646\u062a\u0627 \u062c\u0648\u0631\u062f\u0627"
     ],
-    "name:bel_x_variant":[
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0646\u062a\u0627 \u062c\u0648\u0631\u062f\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Punta Gorda"
+    ],
+    "name:bel_x_preferred":[
         "\u041f\u0443\u043d\u0442\u0430-\u0413\u043e\u0440\u0434\u0430"
     ],
     "name:ben_x_preferred":[
@@ -39,6 +45,9 @@
         "\u03a0\u03bf\u03cd\u03bd\u03c4\u03b1 \u0393\u03cc\u03c1\u03b4\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Punta Gorda"
+    ],
+    "name:epo_x_preferred":[
         "Punta Gorda"
     ],
     "name:fas_x_preferred":[
@@ -266,7 +275,7 @@
         }
     ],
     "wof:id":421201237,
-    "wof:lastmodified":1636500460,
+    "wof:lastmodified":1690863842,
     "wof:name":"Punta Gorda",
     "wof:parent_id":85669343,
     "wof:placetype":"locality",

--- a/data/421/202/805/421202805.geojson
+++ b/data/421/202/805/421202805.geojson
@@ -17,7 +17,13 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:deu_x_preferred":[
+        "Santana"
+    ],
     "name:eng_x_preferred":[
+        "Santana"
+    ],
+    "name:fra_x_preferred":[
         "Santana"
     ],
     "name:nds_x_preferred":[
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":421202805,
-    "wof:lastmodified":1566633226,
+    "wof:lastmodified":1690863841,
     "wof:name":"Santana",
     "wof:parent_id":85669321,
     "wof:placetype":"locality",

--- a/data/421/202/807/421202807.geojson
+++ b/data/421/202/807/421202807.geojson
@@ -20,6 +20,15 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0631\u0648\u0632\u0627\u0644 \u062a\u0627\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0631\u0648\u0632\u0627\u0644 \u062a\u0627\u0648\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Corozal Town"
+    ],
+    "name:bel_x_preferred":[
+        "\u041a\u0430\u0440\u0430\u0441\u0430\u043b\u044c"
+    ],
     "name:deu_x_preferred":[
         "Corozal"
     ],
@@ -28,6 +37,9 @@
     ],
     "name:eng_x_variant":[
         "Corozal Town"
+    ],
+    "name:epo_x_preferred":[
+        "Corozal"
     ],
     "name:fra_x_preferred":[
         "Corozal Town"
@@ -91,6 +103,9 @@
     ],
     "name:tur_x_preferred":[
         "Corozal"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041a\u043e\u0440\u043e\u0441\u0430\u043b\u044c"
     ],
     "name:und_x_variant":[
         "Corasal"
@@ -241,7 +256,7 @@
         }
     ],
     "wof:id":421202807,
-    "wof:lastmodified":1636500459,
+    "wof:lastmodified":1690863841,
     "wof:name":"Corozal",
     "wof:parent_id":85669327,
     "wof:placetype":"locality",

--- a/data/856/325/71/85632571.geojson
+++ b/data/856/325/71/85632571.geojson
@@ -27,6 +27,9 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
+    "name:abk_x_preferred":[
+        "\u0411\u0435\u043b\u0438\u0437"
+    ],
     "name:ace_x_preferred":[
         "Belize"
     ],
@@ -39,6 +42,9 @@
     "name:aka_x_preferred":[
         "Beliz"
     ],
+    "name:aka_x_variant":[
+        "Belize"
+    ],
     "name:als_x_preferred":[
         "Belize"
     ],
@@ -48,14 +54,23 @@
     "name:amh_x_variant":[
         "\u1264\u120a\u12d8"
     ],
+    "name:ami_x_preferred":[
+        "Belize"
+    ],
     "name:ang_x_preferred":[
         "Bel\u012bs"
+    ],
+    "name:anp_x_preferred":[
+        "\u092c\u0947\u0932\u0940\u091c"
     ],
     "name:ara_x_preferred":[
         "\u0628\u0644\u064a\u0632"
     ],
     "name:arg_x_preferred":[
         "Belize"
+    ],
+    "name:ary_x_preferred":[
+        "\u0628\u064a\u0644\u064a\u0632"
     ],
     "name:arz_x_preferred":[
         "\u0628\u064a\u0644\u064a\u0632"
@@ -65,6 +80,9 @@
     ],
     "name:ast_x_variant":[
         "Belice"
+    ],
+    "name:avk_x_preferred":[
+        "Belizea"
     ],
     "name:aym_x_preferred":[
         "Wilisi"
@@ -83,6 +101,9 @@
     ],
     "name:bam_x_variant":[
         "Belizi"
+    ],
+    "name:ban_x_preferred":[
+        "B\u00e9lize"
     ],
     "name:bar_x_preferred":[
         "Belize"
@@ -107,6 +128,9 @@
     ],
     "name:bho_x_preferred":[
         "\u092c\u0947\u0932\u0940\u091c"
+    ],
+    "name:bis_x_preferred":[
+        "Belize"
     ],
     "name:bod_x_preferred":[
         "\u0f56\u0f7a\u0f0b\u0f63\u0f72\u0f0b\u0f5b\u0f72\u0f0d"
@@ -153,11 +177,17 @@
     "name:chv_x_preferred":[
         "\u0411\u0435\u043b\u0438\u0437"
     ],
+    "name:chy_x_preferred":[
+        "Belize"
+    ],
     "name:ckb_x_preferred":[
         "\u0628\u06d5\u0644\u06cc\u0632"
     ],
     "name:cor_x_preferred":[
         "Belisa"
+    ],
+    "name:cos_x_preferred":[
+        "Belise"
     ],
     "name:crh_x_preferred":[
         "Beliz"
@@ -166,6 +196,9 @@
         "Bel\u00ees"
     ],
     "name:cym_x_variant":[
+        "Belize"
+    ],
+    "name:dag_x_preferred":[
         "Belize"
     ],
     "name:dan_x_preferred":[
@@ -251,6 +284,9 @@
     "name:gag_x_preferred":[
         "Beliz"
     ],
+    "name:gcr_x_preferred":[
+        "B\u00e9liz"
+    ],
     "name:gla_x_preferred":[
         "Beilise"
     ],
@@ -267,11 +303,17 @@
         "Belice - Belize",
         "Belice"
     ],
+    "name:glk_x_preferred":[
+        "\u0628\u0644\u06cc\u0632"
+    ],
     "name:glv_x_preferred":[
         "Yn Veleesh"
     ],
     "name:gom_x_preferred":[
         "\u092c\u0947\u0932\u093f\u091d"
+    ],
+    "name:gpe_x_preferred":[
+        "Belize"
     ],
     "name:grn_x_preferred":[
         "Vel\u00edse"
@@ -293,6 +335,9 @@
     ],
     "name:hau_x_preferred":[
         "Beliz"
+    ],
+    "name:hau_x_variant":[
+        "Belize"
     ],
     "name:hbs_x_preferred":[
         "Belize"
@@ -435,6 +480,9 @@
     "name:lit_x_preferred":[
         "Belizas"
     ],
+    "name:lld_x_preferred":[
+        "Belize"
+    ],
     "name:lmo_x_preferred":[
         "Belize"
     ],
@@ -450,6 +498,9 @@
     "name:lzh_x_preferred":[
         "\u4f2f\u5229\u8332"
     ],
+    "name:mad_x_preferred":[
+        "Belize"
+    ],
     "name:mai_x_preferred":[
         "\u092c\u0947\u0932\u093f\u091c"
     ],
@@ -462,8 +513,14 @@
     "name:mar_x_variant":[
         "\u092c\u0947\u0932\u093f\u091d\u0947"
     ],
+    "name:mdf_x_preferred":[
+        "\u0411\u044d\u043b\u0438\u0437"
+    ],
     "name:mhr_x_preferred":[
         "\u0411\u0435\u043b\u0438\u0437"
+    ],
+    "name:min_x_preferred":[
+        "Belize"
     ],
     "name:mkd_x_preferred":[
         "\u0411\u0435\u043b\u0438\u0437"
@@ -480,13 +537,25 @@
     "name:mlt_x_preferred":[
         "Beli\u017ce"
     ],
+    "name:mlt_x_variant":[
+        "Belize"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd5\uabe6\uabc2\uabe4\uabd3\uabe6"
+    ],
     "name:mon_x_preferred":[
         "\u0411\u0435\u043b\u0438\u0437"
+    ],
+    "name:mri_x_preferred":[
+        "P\u0113rihi"
     ],
     "name:mrj_x_preferred":[
         "\u0411\u0435\u043b\u0438\u0437"
     ],
     "name:msa_x_preferred":[
+        "Belize"
+    ],
+    "name:mwl_x_preferred":[
         "Belize"
     ],
     "name:mya_x_preferred":[
@@ -509,6 +578,9 @@
         "Belice"
     ],
     "name:nan_x_preferred":[
+        "Belize"
+    ],
+    "name:nap_x_preferred":[
         "Belize"
     ],
     "name:nau_x_preferred":[
@@ -623,6 +695,9 @@
     "name:san_x_preferred":[
         "\u092c\u0947\u0932\u0940\u091c"
     ],
+    "name:sat_x_preferred":[
+        "\u1c75\u1c6e\u1c5e\u1c64\u1c61\u1c7d"
+    ],
     "name:scn_x_preferred":[
         "Belizi"
     ],
@@ -631,6 +706,9 @@
     ],
     "name:sgs_x_preferred":[
         "Bel\u0117zos"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1015\u1084\u1087\u101c\u102d\u1010\u103a\u1088"
     ],
     "name:sin_x_preferred":[
         "\u0db6\u0dd9\u0dbd\u0dd3\u0dc3\u0dca"
@@ -644,11 +722,23 @@
     "name:sme_x_preferred":[
         "Belize"
     ],
+    "name:smj_x_preferred":[
+        "Belijssa"
+    ],
+    "name:smn_x_preferred":[
+        "Belize"
+    ],
     "name:smo_x_preferred":[
         "Pelisi"
     ],
+    "name:sms_x_preferred":[
+        "Belize"
+    ],
     "name:sna_x_preferred":[
         "Belize"
+    ],
+    "name:snd_x_preferred":[
+        "\u0628\u064a\u0644\u064a\u0632"
     ],
     "name:som_x_preferred":[
         "Belise"
@@ -689,6 +779,9 @@
     "name:szl_x_preferred":[
         "Belize"
     ],
+    "name:szy_x_preferred":[
+        "Belize"
+    ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0bb2\u0bc0\u0b9a\u0bc1"
     ],
@@ -697,6 +790,9 @@
     ],
     "name:tat_x_preferred":[
         "\u0411\u0435\u043b\u0438\u0437"
+    ],
+    "name:tay_x_preferred":[
+        "Belize"
     ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c46\u0c32\u0c3f\u0c1c\u0c4d"
@@ -726,14 +822,23 @@
     "name:tir_x_preferred":[
         "\u1264\u120a\u12d8"
     ],
+    "name:tok_x_preferred":[
+        "ma Peli"
+    ],
     "name:ton_x_preferred":[
         "Pelise"
+    ],
+    "name:trv_x_preferred":[
+        "Belize"
     ],
     "name:tuk_x_preferred":[
         "Belize"
     ],
     "name:tur_x_preferred":[
         "Belize"
+    ],
+    "name:udm_x_preferred":[
+        "\u0411\u0435\u043b\u0438\u0437"
     ],
     "name:uig_x_preferred":[
         "\u0628\u06d0\u0644\u0649\u0632"
@@ -1043,7 +1148,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1618362673,
+    "wof:lastmodified":1690863840,
     "wof:name":"Belize",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/693/21/85669321.geojson
+++ b/data/856/693/21/85669321.geojson
@@ -62,6 +62,9 @@
     "name:eng_x_variant":[
         "Belize District"
     ],
+    "name:epo_x_preferred":[
+        "Belizo"
+    ],
     "name:fas_x_preferred":[
         "\u0646\u0627\u062d\u06cc\u0647 \u0628\u0644\u06cc\u0632"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca8\ub9ac\uc988 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubca8\ub9ac\uc988\uad6c"
     ],
     "name:lad_x_preferred":[
         "Belize"
@@ -288,7 +294,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500454,
+    "wof:lastmodified":1690863838,
     "wof:name":"Belize",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/23/85669323.geojson
+++ b/data/856/693/23/85669323.geojson
@@ -62,6 +62,9 @@
     "name:epo_x_preferred":[
         "Cayo"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u06a9\u0627\u06cc\u0648"
+    ],
     "name:fin_x_preferred":[
         "Cayon kaupunginosa"
     ],
@@ -106,6 +109,9 @@
     ],
     "name:kor_x_preferred":[
         "\uce74\uc694 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uce74\uc694\uad6c"
     ],
     "name:lad_x_preferred":[
         "Cayo"
@@ -303,7 +309,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500455,
+    "wof:lastmodified":1690863839,
     "wof:name":"Cayo",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/27/85669327.geojson
+++ b/data/856/693/27/85669327.geojson
@@ -44,6 +44,9 @@
     "name:ceb_x_preferred":[
         "Corozal District"
     ],
+    "name:ces_x_preferred":[
+        "Distrikt Corozal"
+    ],
     "name:dan_x_preferred":[
         "Corozal"
     ],
@@ -100,6 +103,9 @@
     ],
     "name:kor_x_preferred":[
         "\ucf54\ub85c\uc0b4 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ucf54\ub85c\uc0b4\uad6c"
     ],
     "name:lad_x_preferred":[
         "Corozal"
@@ -300,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500454,
+    "wof:lastmodified":1690863838,
     "wof:name":"Corozal",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/31/85669331.geojson
+++ b/data/856/693/31/85669331.geojson
@@ -35,6 +35,9 @@
     "name:ara_x_variant":[
         "\u0645\u0642\u0627\u0637\u0639\u0629 \u0623\u0648\u0631\u0627\u0646\u062c \u0648\u0648\u0643"
     ],
+    "name:ast_x_preferred":[
+        "distritu d'Orange Walk"
+    ],
     "name:ben_x_preferred":[
         "\u0993\u09b0\u09c7\u099e\u09cd\u099c \u0993\u09af\u09bc\u09be\u0995 \u099c\u09c7\u09b2\u09be"
     ],
@@ -106,6 +109,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc624\ub80c\uc9c0\uc6cc\ud06c \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc624\ub80c\uc9c0\uc6cc\ud06c\uad6c"
     ],
     "name:lad_x_preferred":[
         "Orange Walk"
@@ -306,7 +312,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500455,
+    "wof:lastmodified":1690863839,
     "wof:name":"Orange Walk",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/37/85669337.geojson
+++ b/data/856/693/37/85669337.geojson
@@ -59,6 +59,9 @@
     "name:eng_x_variant":[
         "Stann Creek District"
     ],
+    "name:epo_x_preferred":[
+        "Stann Creek"
+    ],
     "name:fas_x_preferred":[
         "\u0646\u0627\u062d\u06cc\u0647 \u0627\u0633\u062a\u0627\u0646 \u06a9\u0631\u06cc\u06a9"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc2a4\ud0e0\ud06c\ub9ac\ud06c \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc2a4\ud0e0\ud06c\ub9ac\ud06c\uad6c"
     ],
     "name:lad_x_preferred":[
         "Stann Creek"
@@ -305,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500455,
+    "wof:lastmodified":1690863839,
     "wof:name":"Stann Creek",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/43/85669343.geojson
+++ b/data/856/693/43/85669343.geojson
@@ -62,6 +62,9 @@
     "name:eng_x_variant":[
         "Toledo District"
     ],
+    "name:epo_x_preferred":[
+        "Toledo"
+    ],
     "name:fas_x_preferred":[
         "\u0646\u0627\u062d\u06cc\u0647 \u062a\u0648\u0644\u06cc\u062f\u0648"
     ],
@@ -109,6 +112,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud138\ub9ac\ub3c4 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud138\ub9ac\ub3c4\uad6c"
     ],
     "name:lad_x_preferred":[
         "Toledo"
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500455,
+    "wof:lastmodified":1690863838,
     "wof:name":"Toledo",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/890/429/593/890429593.geojson
+++ b/data/890/429/593/890429593.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Benque Viejo del Carmen"
+    ],
     "name:ceb_x_preferred":[
         "Benque Viejo del Carmen"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:lit_x_preferred":[
         "Benke Vjecho del Karmenas"
+    ],
+    "name:nds_x_preferred":[
+        "Benque Viejo del Carmen"
     ],
     "name:nld_x_preferred":[
         "Benque Viejo del Carmen"
@@ -106,7 +112,7 @@
         }
     ],
     "wof:id":890429593,
-    "wof:lastmodified":1566633228,
+    "wof:lastmodified":1690863843,
     "wof:name":"Benque Viejo del Carmen",
     "wof:parent_id":85669323,
     "wof:placetype":"locality",

--- a/data/890/432/795/890432795.geojson
+++ b/data/890/432/795/890432795.geojson
@@ -22,7 +22,13 @@
     "name:ara_x_preferred":[
         "\u0641\u0627\u0644\u064a \u0623\u0648\u0641 \u0628\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0627\u0644\u0649 \u0627\u0648\u0641 \u0628\u064a\u0633"
+    ],
     "name:ceb_x_preferred":[
+        "Valley of Peace"
+    ],
+    "name:deu_x_preferred":[
         "Valley of Peace"
     ],
     "name:eng_x_preferred":[
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890432795,
-    "wof:lastmodified":1566633229,
+    "wof:lastmodified":1690863844,
     "wof:name":"Valley of Peace",
     "wof:parent_id":85669323,
     "wof:placetype":"locality",

--- a/data/890/434/951/890434951.geojson
+++ b/data/890/434/951/890434951.geojson
@@ -19,13 +19,22 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "San Pedro Town"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0430\u043d-\u041f\u0435\u0434\u0440\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0421\u0430\u043d-\u041f\u0435\u0434\u0440\u0430"
     ],
     "name:bre_x_preferred":[
         "San Pedro Town"
     ],
     "name:ceb_x_preferred":[
+        "San Pedro"
+    ],
+    "name:ces_x_preferred":[
         "San Pedro"
     ],
     "name:deu_x_preferred":[
@@ -34,7 +43,13 @@
     "name:eng_x_preferred":[
         "San Pedro Town"
     ],
+    "name:eus_x_preferred":[
+        "San Pedro"
+    ],
     "name:fra_x_preferred":[
+        "San Pedro"
+    ],
+    "name:frr_x_preferred":[
         "San Pedro"
     ],
     "name:heb_x_preferred":[
@@ -51,6 +66,9 @@
     ],
     "name:lit_x_preferred":[
         "San Pedras"
+    ],
+    "name:nds_x_preferred":[
+        "San Pedro Town"
     ],
     "name:nld_x_preferred":[
         "San Pedro Town"
@@ -134,7 +152,7 @@
         }
     ],
     "wof:id":890434951,
-    "wof:lastmodified":1636500460,
+    "wof:lastmodified":1690863844,
     "wof:name":"San Pedro",
     "wof:parent_id":85669321,
     "wof:placetype":"locality",

--- a/data/890/442/105/890442105.geojson
+++ b/data/890/442/105/890442105.geojson
@@ -33,17 +33,36 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u0645\u0648\u0628\u0627\u0646"
     ],
+    "name:arg_x_preferred":[
+        "Belmopan"
+    ],
+    "name:ary_x_preferred":[
+        "\u0628\u064a\u0644\u0645\u0648\u067e\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0644\u0645\u0648\u0628\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
+        "Belmopan"
+    ],
+    "name:ast_x_variant":[
+        "Belmop\u00e1n"
+    ],
+    "name:avk_x_preferred":[
         "Belmopan"
     ],
     "name:aze_x_preferred":[
         "Belmopan"
     ],
+    "name:ban_x_preferred":[
+        "B\u00e9lmopan"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0435\u043b\u044c\u043c\u0430\u043f\u0430\u043d"
     ],
     "name:bel_x_variant":[
-        "\u0411\u044d\u043b\u044c\u043c\u0430\u043f\u0430\u043d"
+        "\u0411\u044d\u043b\u044c\u043c\u0430\u043f\u0430\u043d",
+        "\u0411\u0435\u043b\u044c\u043c\u0430\u043f\u0430\u043d"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u09b2\u09ae\u09cb\u09aa\u09be\u09a8"
@@ -113,6 +132,9 @@
     ],
     "name:frp_x_preferred":[
         "B\u00e8lmopan"
+    ],
+    "name:frr_x_preferred":[
+        "Belmopan"
     ],
     "name:fry_x_preferred":[
         "Belmopan"
@@ -207,6 +229,9 @@
     "name:lfn_x_preferred":[
         "Belmopan"
     ],
+    "name:lij_x_preferred":[
+        "Belmopan"
+    ],
     "name:lit_x_preferred":[
         "Belmopanas"
     ],
@@ -215,6 +240,9 @@
     ],
     "name:mar_x_preferred":[
         "\u092c\u0947\u0932\u094d\u092e\u094b\u092a\u093e\u0928"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0411\u044d\u043b\u044c\u043c\u043e\u043f\u0430\u043d"
     ],
     "name:mkd_x_preferred":[
         "\u0411\u0435\u043b\u043c\u043e\u043f\u0430\u043d"
@@ -275,6 +303,9 @@
     ],
     "name:por_x_preferred":[
         "Belmopan"
+    ],
+    "name:pus_x_preferred":[
+        "\u0628\u0644\u0645\u0648\u067e\u0627\u0646"
     ],
     "name:que_x_preferred":[
         "Belmopan"
@@ -339,6 +370,9 @@
     "name:tel_x_preferred":[
         "\u0c2c\u0c46\u0c32\u0c4d\u0c2e\u0c4b\u0c2a\u0c3e\u0c28\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0411\u0435\u043b\u043c\u043e\u043f\u0430\u043d"
+    ],
     "name:tgl_x_preferred":[
         "Belmopan"
     ],
@@ -347,6 +381,9 @@
     ],
     "name:tur_x_preferred":[
         "Belmop\u00e1n"
+    ],
+    "name:udm_x_preferred":[
+        "\u0411\u0435\u043b\u044c\u043c\u043e\u043f\u0430\u043d"
     ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u043b\u044c\u043c\u043e\u043f\u0430\u043d"
@@ -358,6 +395,9 @@
         "\u0628\u0644\u0645\u0648\u067e\u0627\u0646"
     ],
     "name:uzb_x_preferred":[
+        "Belmopan"
+    ],
+    "name:vec_x_preferred":[
         "Belmopan"
     ],
     "name:vep_x_preferred":[
@@ -374,6 +414,9 @@
     ],
     "name:war_x_preferred":[
         "Belmopan"
+    ],
+    "name:wuu_x_preferred":[
+        "\u8d1d\u5c14\u83ab\u6f58"
     ],
     "name:xmf_x_preferred":[
         "\u10d1\u10d4\u10da\u10db\u10dd\u10de\u10d0\u10dc\u10d8"
@@ -534,7 +577,7 @@
         }
     ],
     "wof:id":890442105,
-    "wof:lastmodified":1607390890,
+    "wof:lastmodified":1690863843,
     "wof:name":"Belmopan",
     "wof:parent_id":85669323,
     "wof:placetype":"locality",

--- a/data/890/451/721/890451721.geojson
+++ b/data/890/451/721/890451721.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u062f\u0627\u0646\u063a\u0631\u064a\u063a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0627\u0646\u062c\u0631\u064a\u062c\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Dangriga"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0414\u0430\u043d\u0440\u044b\u0433\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0414\u0430\u043d\u0433\u0440\u044b\u0433\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u09be\u0982\u0997\u09cd\u09b0\u09bf\u0997\u09be"
@@ -54,6 +63,9 @@
         "Stanncrek",
         "Dangriga Town, Dangriga",
         "Stann Creek Village",
+        "Dangriga"
+    ],
+    "name:epo_x_preferred":[
         "Dangriga"
     ],
     "name:fas_x_preferred":[
@@ -88,6 +100,12 @@
     ],
     "name:mar_x_preferred":[
         "\u0921\u093e\u0902\u0917\u094d\u0930\u093f\u0917\u093e"
+    ],
+    "name:nah_x_preferred":[
+        "Dangriga"
+    ],
+    "name:nds_x_preferred":[
+        "Dangriga"
     ],
     "name:nld_x_preferred":[
         "Dangriga"
@@ -265,7 +283,7 @@
         }
     ],
     "wof:id":890451721,
-    "wof:lastmodified":1636500460,
+    "wof:lastmodified":1690863843,
     "wof:name":"Dangriga",
     "wof:parent_id":85669337,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.