### PR TITLE
bz concordances, placetype local, and more

### DIFF
--- a/data/421/172/491/421172491.geojson
+++ b/data/421/172/491/421172491.geojson
@@ -136,7 +136,7 @@
         }
     ],
     "wof:id":421172491,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886753,
     "wof:name":"Dolores",
     "wof:parent_id":85669323,
     "wof:placetype":"county",

--- a/data/421/181/671/421181671.geojson
+++ b/data/421/181/671/421181671.geojson
@@ -84,7 +84,7 @@
         }
     ],
     "wof:id":421181671,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695886972,
     "wof:name":"Othon P. Blanco",
     "wof:parent_id":85669327,
     "wof:placetype":"county",

--- a/data/856/325/71/85632571.geojson
+++ b/data/856/325/71/85632571.geojson
@@ -1117,6 +1117,7 @@
         "hasc:id":"BZ",
         "icao:code":"V3",
         "ioc:id":"BIZ",
+        "iso:code":"BZ",
         "itu:id":"BLZ",
         "loc:id":"n79126944",
         "m49:code":"084",
@@ -1131,6 +1132,7 @@
         "wk:page":"Belize",
         "wmo:id":"BH"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BZ",
     "wof:country_alpha3":"BLZ",
     "wof:geom_alt":[
@@ -1152,7 +1154,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639631,
+    "wof:lastmodified":1695881293,
     "wof:name":"Belize",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/693/21/85669321.geojson
+++ b/data/856/693/21/85669321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.30463,
-    "geom:area_square_m":3591130646.045927,
+    "geom:area_square_m":3591129249.777214,
     "geom:bbox":"-88.641302,17.104486,-87.484202,18.209174",
     "geom:latitude":17.566276,
     "geom:longitude":-88.370863,
@@ -270,16 +270,18 @@
         "gn:id":3582676,
         "gp:id":2344794,
         "hasc:id":"BZ.BZ",
+        "iso:code":"BZ-BZ",
         "iso:id":"BZ-BZ",
         "qs_pg:id":913359,
         "wd:id":"Q506056",
         "wk:page":"Belize District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32b7558b31333338b1ceff675beac613",
+    "wof:geomhash":"a89d1973ddaeea7c2b98bbdefa211cc0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690863838,
+    "wof:lastmodified":1695884866,
     "wof:name":"Belize",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/23/85669323.geojson
+++ b/data/856/693/23/85669323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.445465,
-    "geom:area_square_m":5267509476.679489,
+    "geom:area_square_m":5267508461.816799,
     "geom:bbox":"-89.19314,16.392626,-88.548285,17.48994",
     "geom:latitude":17.000009,
     "geom:longitude":-88.897456,
@@ -287,14 +287,16 @@
         "gn:id":3582429,
         "gp:id":2344795,
         "hasc:id":"BZ.CY",
+        "iso:code":"BZ-CY",
         "iso:id":"BZ-CY",
         "qs_pg:id":1222230,
         "unlc:id":"BZ-CY",
         "wd:id":"Q508773",
         "wk:page":"Cayo District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BZ",
-    "wof:geomhash":"cb06946ef25d38a5368bf8d3b7d64a5a",
+    "wof:geomhash":"68170fcbc7961dc84367ca8353da832c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690863839,
+    "wof:lastmodified":1695884866,
     "wof:name":"Cayo",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/27/85669327.geojson
+++ b/data/856/693/27/85669327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.168597,
-    "geom:area_square_m":1980136760.527995,
+    "geom:area_square_m":1980136798.534098,
     "geom:bbox":"-88.614059,17.959946,-88.083567,18.490759",
     "geom:latitude":18.227893,
     "geom:longitude":-88.320626,
@@ -284,14 +284,16 @@
         "gn:id":3582302,
         "gp:id":2344796,
         "hasc:id":"BZ.CZ",
+        "iso:code":"BZ-CZL",
         "iso:id":"BZ-CZL",
         "qs_pg:id":894845,
         "unlc:id":"BZ-CZL",
         "wd:id":"Q512273",
         "wk:page":"Corozal District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BZ",
-    "wof:geomhash":"6242bcf120a52c91121ecdeefc88322e",
+    "wof:geomhash":"c9ede6dc0caac72ca5f69639359d9579",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690863838,
+    "wof:lastmodified":1695884866,
     "wof:name":"Corozal",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/31/85669331.geojson
+++ b/data/856/693/31/85669331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.401654,
-    "geom:area_square_m":4729566920.37648,
+    "geom:area_square_m":4729566328.663979,
     "geom:bbox":"-89.161375,17.321032,-88.284347,18.247028",
     "geom:latitude":17.768711,
     "geom:longitude":-88.812787,
@@ -290,14 +290,16 @@
         "gn:id":3581511,
         "gp:id":2344797,
         "hasc:id":"BZ.OW",
+        "iso:code":"BZ-OW",
         "iso:id":"BZ-OW",
         "qs_pg:id":235563,
         "unlc:id":"BZ-OW",
         "wd:id":"Q506036",
         "wk:page":"Orange Walk District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BZ",
-    "wof:geomhash":"c728301abcbab06a36fe9e693b6df62a",
+    "wof:geomhash":"b090dc4469b548730d7c74a73f7de1a8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690863839,
+    "wof:lastmodified":1695884866,
     "wof:name":"Orange Walk",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/37/85669337.geojson
+++ b/data/856/693/37/85669337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.209105,
-    "geom:area_square_m":2474840177.460628,
+    "geom:area_square_m":2474841828.998016,
     "geom:bbox":"-88.777625,16.435167,-87.78425,17.135735",
     "geom:latitude":16.832263,
     "geom:longitude":-88.463687,
@@ -286,17 +286,19 @@
         "gn:id":3580975,
         "gp:id":2344798,
         "hasc:id":"BZ.SC",
+        "iso:code":"BZ-SC",
         "iso:id":"BZ-SC",
         "qs_pg:id":890034,
         "unlc:id":"BZ-SC",
         "wd:id":"Q502652",
         "wk:page":"Stann Creek District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f49bcc5e3e4627d3328f5146a6c98d88",
+    "wof:geomhash":"22899eebb0765548738c72523e71e35b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690863839,
+    "wof:lastmodified":1695884866,
     "wof:name":"Stann Creek",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/856/693/43/85669343.geojson
+++ b/data/856/693/43/85669343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.368002,
-    "geom:area_square_m":4367484388.80942,
+    "geom:area_square_m":4367483939.247528,
     "geom:bbox":"-89.236512,15.879652,-88.190012,16.69185",
     "geom:latitude":16.299763,
     "geom:longitude":-88.881366,
@@ -289,17 +289,19 @@
         "gn:id":3580913,
         "gp:id":2344799,
         "hasc:id":"BZ.TO",
+        "iso:code":"BZ-TOL",
         "iso:id":"BZ-TOL",
         "qs_pg:id":890033,
         "unlc:id":"BZ-TOL",
         "wd:id":"Q506049",
         "wk:page":"Toledo District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb1a2b5ffdd998a4f4847c30ffaae291",
+    "wof:geomhash":"61e18e0d047d823823a810bb8bf27fc6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -314,7 +316,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690863838,
+    "wof:lastmodified":1695884866,
     "wof:name":"Toledo",
     "wof:parent_id":85632571,
     "wof:placetype":"region",

--- a/data/890/429/623/890429623.geojson
+++ b/data/890/429/623/890429623.geojson
@@ -86,7 +86,7 @@
         }
     ],
     "wof:id":890429623,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886226,
     "wof:name":"Hopelch\u00e9n",
     "wof:parent_id":85669331,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.